### PR TITLE
Statically serve DNS records for our public domains

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -31,6 +31,13 @@ curl --verbose -f ${MAISON_WEB_PROTOCOL}://${MAISON_VCS_DOMAIN} > /dev/null
 # Connect to Drone.
 ./bin/await maison_ci_1 8000
 curl --verbose -f ${MAISON_WEB_PROTOCOL}://${MAISON_CI_DOMAIN} > /dev/null
+# Connect to the DNS server.
+./bin/wait-for-it localhost:5300
+MAISON_DOMAINS="$MAISON_NETWORK_DOMAIN $MAISON_HAB_DOMAIN $MAISON_OLA_DOMAIN $MAISON_VCS_DOMAIN $MAISON_CI_DOMAIN"
+for domain in ${MAISON_DOMAINS}; do
+    resolved_ip=`docker exec maison_dns_1 getent hosts $domain | awk '{ print $1 }'`
+    ip addr show | grep $resolved_ip
+done
 
 htpasswd -D ./services/web/data/htpasswd $username
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,5 +163,21 @@ services:
       MAISON_OLA_DOMAIN: '${MAISON_OLA_DOMAIN}'
       MAISON_VCS_DOMAIN: '${MAISON_VCS_DOMAIN}'
       MAISON_CI_DOMAIN: '${MAISON_CI_DOMAIN}'
+  dns:
+    image: maison:dns
+    build: ./services/dns
+    restart: on-failure
+    volumes:
+      - '/etc/localtime:/etc/localtime:ro'
+      - '/etc/timezone:/etc/timezone:ro'
+    ports:
+     - '5300:53'
+     - '5300:53/udp'
+    networks:
+      maison:
+        aliases:
+          - dns
+    environment:
+      MAISON_DOMAINS: '${MAISON_NETWORK_DOMAIN} ${MAISON_HAB_DOMAIN} ${MAISON_OLA_DOMAIN} ${MAISON_VCS_DOMAIN} ${MAISON_CI_DOMAIN}'
 networks:
   maison:

--- a/services/dns/Dockerfile
+++ b/services/dns/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.7
+
+RUN apk --no-cache add bash dnsmasq
+
+COPY ./run /maison/run
+
+EXPOSE 53 53/udp
+
+ENTRYPOINT ["bash", "/maison/run"]

--- a/services/dns/run
+++ b/services/dns/run
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+set -e
+
+MAISON_HOST_IP=$(ip route show | awk '/default/ {print $3}')
+
+for domain in ${MAISON_DOMAINS}; do
+    echo "$MAISON_HOST_IP $domain" >> /etc/hosts
+done
+
+dnsmasq -d


### PR DESCRIPTION
Statically serve DNS records for our public domains and resolve them to internal IP addresses, so requests do not have to leave the network.