### PR TITLE
Improve udev rule building

### DIFF
--- a/build/50-udev-ftdi
+++ b/build/50-udev-ftdi
@@ -4,4 +4,9 @@ set -Eeuo pipefail
 
 cd "$(dirname "$0")/.."
 
-docker run --entrypoint /bin/cat bartfeenstra/ola:0.1 /etc/udev/rules.d/ftdi.rules | sudo tee -a /etc/udev/rules.d/ftdi.rules
+target=/etc/udev/rules.d/maison-ola-ftdi.rules
+new_rules=$(docker run --entrypoint /bin/cat bartfeenstra/ola:0.1 /etc/udev/rules.d/ftdi.rules)
+if [ ! -f "$target" ] ||  [ "$(cat "$target")" != "$new_rules" ]; then
+    ./vendor/krab/bin/krab stdio-inform "Updating udev rules in $target..."
+    sudo bash -c "echo '$new_rules' > '$target'"
+fi

--- a/migrations/6-namespace-ftdi-rules
+++ b/migrations/6-namespace-ftdi-rules
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+cd "$(dirname "$0")/.."
+
+old=/etc/udev/rules.d/ftdi.rules
+new=/etc/udev/rules.d/maison-ola-ftdi.rules
+if [ -f "$old" ] && [ ! -f "$new" ]; then
+    ./vendor/krab/bin/krab stdio-inform "Moving $old to $new..."
+    sudo mv "$old" "$new"
+fi


### PR DESCRIPTION
Fix a bug that would add udev rules on every build, and only require privilege escalation when a change must be made.